### PR TITLE
NEW add symlink compatible relative paths

### DIFF
--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -119,7 +119,7 @@
 
 	if ($path != '') {
 		// if the load was not successful then we empty the path from this file
-        if ($saved = @file_put_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php", $path)) {
+        if (!empty($_SERVER['SCRIPT_FILENAME']) && $saved = @file_put_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php", $path)) {
             return;
         } else {
             @file_put_contents("../main_module_inc_php", $path);

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -32,13 +32,15 @@
 
 // 1. try to get the location of main.inc.php from PHYSICAL TEXT FILE
 
-	if (file_exists(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php")) {
+	$path = '';
+
+	if (!empty($_SERVER['SCRIPT_FILENAME']) && file_exists(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php")) {
 		$path = @file_get_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php");
 		if (file_exists($path) && @include $path) {
 			return;
 		}
 	}
-	if (file_exists("../main_module_inc_php")) {
+	if ($path == '' && file_exists("../main_module_inc_php")) {
 		$path = @file_get_contents("../main_module_inc_php");
 		if (file_exists($path) && @include $path) {
 			return;
@@ -46,8 +48,6 @@
 	}
 
 // 2. Try into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
-
-	$path = '';
 
 	if (!empty($_SERVER["CONTEXT_DOCUMENT_ROOT"]) && file_exists($_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php")){
 		if (@include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php") {

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -97,16 +97,16 @@
 // 6. last try, with the PATH passed from the <FORM> in this script to let the user indicate the path
 
 	if ($path == '' && !empty($_POST['main_inc_php_path'])){
-				
+
 		// check that the proposed file is really main.inc.php and not other malicious file
 		if (substr($_POST['main_inc_php_path'], -13) == '/main.inc.php' && file_exists($_POST['main_inc_php_path'])) {
-					
+
 			// prevent a hacker from trying to upload a file submitted by him
 			// we check existence of usual Dolibarr directories of core modules (a few it's enough)
 			$dir = dirname($_POST['main_inc_php_path']); // ex: ../..
 			$sep = DIRECTORY_SEPARATOR;
 			if (is_dir($dir.$sep.'fourn') && is_dir($dir.$sep.'fourn'.$sep.'facture') && is_dir($dir.$sep.'fourn'.$sep.'facture'.$sep.'tpl')){
-			
+
 				define('NOCSRFCHECK',1); // this disable for this unique call the check of the CSRF security token!
 				if (@include $_POST['main_inc_php_path']) {
 					$path = $_POST['main_inc_php_path'];

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -32,8 +32,6 @@
 
 // 1. try to get the location of main.inc.php from PHYSICAL TEXT FILE
 
-	$path = '';
-
 	if (file_exists(__DIR__."/../main_module_inc_php")) {
 		$path = @file_get_contents(__DIR__."/../main_module_inc_php");
 		if (file_exists($path) && @include $path) {
@@ -41,6 +39,8 @@
 		}
 	}
 // 2. Try into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
+
+	$path = '';
 
 	if (!empty($_SERVER["CONTEXT_DOCUMENT_ROOT"]) && file_exists($_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php")){
 		if (@include $_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php") {

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -34,8 +34,8 @@
 
 	$path = '';
 
-	if (file_exists(__DIR__."/main_module_inc_php")) {
-		$path = @file_get_contents(__DIR__."/main_module_inc_php");
+	if (file_exists(__DIR__."/../main_module_inc_php")) {
+		$path = @file_get_contents(__DIR__."/../main_module_inc_php");
 		if (file_exists($path) && @include $path) {
 			return;
 		}
@@ -112,7 +112,7 @@
 
 	if ($path != '') {
 		// if the load was not successful then we empty the path from this file
-        @file_put_contents(__DIR__."/main_module_inc_php", $path);
+        @file_put_contents(__DIR__."/../main_module_inc_php", $path);
 		return;
 	}
 

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -32,6 +32,12 @@
 
 // 1. try to get the location of main.inc.php from PHYSICAL TEXT FILE
 
+	if (file_exists(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php")) {
+		$path = @file_get_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php");
+		if (file_exists($path) && @include $path) {
+			return;
+		}
+	}
 	if (file_exists("../main_module_inc_php")) {
 		$path = @file_get_contents("../main_module_inc_php");
 		if (file_exists($path) && @include $path) {
@@ -113,8 +119,12 @@
 
 	if ($path != '') {
 		// if the load was not successful then we empty the path from this file
-		@file_put_contents("../main_module_inc_php", $path);
-		return;
+        if ($saved = @file_put_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php", $path)) {
+            return;
+        } else {
+            @file_put_contents("../main_module_inc_php", $path);
+		    return;
+        }
 	}
 
 // we did not accomplished to load the main.inc.php

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -23,7 +23,7 @@
  *
  * 	2. at the top of any PHP file of your module needing to load main.inc.php put his:
  *
- * 		include_once('main_module.inc.php');
+ * 		include_once 'main_module.inc.php';
  *
  */
 
@@ -34,19 +34,12 @@
 
 	$path = '';
 
-	if (!empty($_SERVER['SCRIPT_FILENAME']) && file_exists(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php")) {
-		$path = @file_get_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php");
+	if (file_exists(__DIR__."/main_module_inc_php")) {
+		$path = @file_get_contents(__DIR__."/main_module_inc_php");
 		if (file_exists($path) && @include $path) {
 			return;
 		}
 	}
-	if ($path == '' && file_exists("../main_module_inc_php")) {
-		$path = @file_get_contents("../main_module_inc_php");
-		if (file_exists($path) && @include $path) {
-			return;
-		}
-	}
-
 // 2. Try into web root known defined into CONTEXT_DOCUMENT_ROOT (not always defined)
 
 	if (!empty($_SERVER["CONTEXT_DOCUMENT_ROOT"]) && file_exists($_SERVER["CONTEXT_DOCUMENT_ROOT"]."/main.inc.php")){
@@ -119,12 +112,8 @@
 
 	if ($path != '') {
 		// if the load was not successful then we empty the path from this file
-        if (!empty($_SERVER['SCRIPT_FILENAME']) && $saved = @file_put_contents(dirname(dirname($_SERVER['SCRIPT_FILENAME']))."/main_module_inc_php", $path)) {
-            return;
-        } else {
-            @file_put_contents("../main_module_inc_php", $path);
-		    return;
-        }
+        @file_put_contents(__DIR__."/main_module_inc_php", $path);
+		return;
 	}
 
 // we did not accomplished to load the main.inc.php


### PR DESCRIPTION
If we use symlinks into Dolibarr’s `custom` directory (which I do in my development environment), then "../" won’t be custom but the original file’s location folder. And, as this is an include, the path will be relative from the file it has been included from.
~~In order to avoid that, first try with `dirname(dirname($_SERVER['SCRIPT_FILENAME']))` will put it in `custom` (if `$_SERVER['SCRIPT_FILENAME']` is usable, which is why we can’t forget about the ../ approach).~~
We cannot go from an included file in a symlinked directory to the link path. So, the better way (for me) is to save `main_module_inc_php` at the root of the module folder.
What do you think ?