### PR TITLE
FIX: php warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ include_once('../main_module.inc.php');
 
 # Compatibility with Windows
 
-It has been attempted to make it 100% compatible with Windows OS. As you should know, the main difference in this area is the use of the symbol "\" instead of "/" to separate directories in a path. The script uses the native PHP constant called DIRECTORY_SEPARATOR to separate directories in the paths. Even so, if you detect any inconsistency in your Windows installation, let us know.
+It has been attempted to make it 100% compatible with Windows OS. As you should know, the main difference in this area is the use of the symbol "\\" instead of "/" to separate directories in a path. The script uses the native PHP constant called DIRECTORY_SEPARATOR to separate directories in the paths. Even so, if you detect any inconsistency in your Windows installation, let us know.
 
-In the 2.0 version has been fixed some "odd things" used by PHP in a Windwos environment. For example, when you retrieve $_SERVER['SCRIPT_FILENAME'] it returns a file path using the UNIX  directory separatorr (/) instead of the windows one (\) !!??
+In the 2.0 version has been fixed some "odd things" used by PHP in a Windwos environment. For example, when you retrieve $_SERVER['SCRIPT_FILENAME'] it returns a file path using the UNIX  directory separatorr (/) instead of the windows one (\\) !!??
 
 # Compatibility with Dolistore
 

--- a/main_module.inc.php
+++ b/main_module.inc.php
@@ -300,7 +300,7 @@ function get_parent_absolute_path()
 		}
 	}
 	array_pop($absolutes);
-	if (substr($parts[0], -1)==':') {
+	if (isset($parts[0]) && substr($parts[0], -1) == ':') {
 		// windows C:\xampp\htdocs\...
 		return implode(DIRECTORY_SEPARATOR, $absolutes);
 	} else {


### PR DESCRIPTION
PHP 8 will raise a warning if we do not check if said array key exists.

Additionally, a very minor adjustment in the README : backslash must be escaped with another backslash in order to be displayed in markdown